### PR TITLE
Adding a Mutex for the metrics stats on both Client and Server

### DIFF
--- a/webtunnelclient/client.go
+++ b/webtunnelclient/client.go
@@ -54,6 +54,7 @@ type WebtunnelClient struct {
 	ifce         *Interface             // Struct to hold interface configuration.
 	userInitFunc func(*Interface) error // User supplied callback for OS initialization.
 	wsWriteLock  sync.Mutex             // Lock for Websocket Writes.
+	metricsLock  sync.Mutex             // Lock for Metrics Writes.
 	packetCnt    int                    // Count of packets.
 	bytesCnt     int                    // Count of bytes.
 	serverIPPort string                 // Websocket serverIP:Port.
@@ -243,8 +244,10 @@ func (w *WebtunnelClient) Stop() error {
 
 // ResetMetrics reset the internal counters.
 func (w *WebtunnelClient) ResetMetrics() {
+	w.metricsLock.Lock()
 	w.packetCnt = 0
 	w.bytesCnt = 0
+	w.metricsLock.Unlock()
 }
 
 // GetMetrics returns the internal metrics.
@@ -320,8 +323,10 @@ func (w *WebtunnelClient) processWSPacket() {
 			w.Error <- fmt.Errorf("error writing to tunnel %s", err)
 			return
 		}
+		w.metricsLock.Lock()
 		w.packetCnt++
 		w.bytesCnt += n
+		w.metricsLock.Unlock()
 	}
 }
 

--- a/webtunnelserver/webtunnelserver.go
+++ b/webtunnelserver/webtunnelserver.go
@@ -56,7 +56,7 @@ type WebTunnelServer struct {
 	metrics            *Metrics                   // Metrics.
 	secure             bool                       // Start Server with https.
 	customHTTPHandlers map[string]http.Handler    // Array of custom HTTP handlers.
-	metricsLock	   sync.Mutex                 // Mutex for metrics write
+	metricsLock        sync.Mutex                 // Mutex for metrics write
 }
 
 /*

--- a/webtunnelserver/webtunnelserver.go
+++ b/webtunnelserver/webtunnelserver.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 
 	wc "github.com/deepakkamesh/webtunnel/webtunnelcommon"
 	"github.com/golang/glog"
@@ -55,6 +56,7 @@ type WebTunnelServer struct {
 	metrics            *Metrics                   // Metrics.
 	secure             bool                       // Start Server with https.
 	customHTTPHandlers map[string]http.Handler    // Array of custom HTTP handlers.
+	metricsLock	   sync.Mutex                 // Mutex for metrics write
 }
 
 /*
@@ -174,8 +176,10 @@ func (r *WebTunnelServer) processTUNPacket() {
 		oPkt = pkt[:n]
 
 		// Add to metrics.
+		r.metricsLock.Lock()
 		r.metrics.Bytes += n
 		r.metrics.Packets++
+		r.metricsLock.Unlock()
 
 		// Get dst IP and corresponding websocket connection.
 		packet := gopacket.NewPacket(oPkt, layers.LayerTypeIPv4, gopacket.Default)
@@ -283,8 +287,10 @@ func (r *WebTunnelServer) wsEndpoint(w http.ResponseWriter, rcv *http.Request) {
 				r.Error <- fmt.Errorf("error writing to tunnel %s", err)
 			}
 			// Add to metrics.
+			r.metricsLock.Lock()
 			r.metrics.Bytes += n
 			r.metrics.Packets++
+			r.metricsLock.Unlock()
 		case websocket.PongMessage: // Pong message from the client
 			// get IP of client
 			// check timeStamp of send + reply
@@ -328,7 +334,9 @@ func (r *WebTunnelServer) DumpAllocations() map[string]*UserInfo {
 
 // ResetMetrics resets the metrics on the server.
 func (r *WebTunnelServer) ResetMetrics() {
+	r.metricsLock.Lock()
 	r.metrics.Users = 0
 	r.metrics.Packets = 0
 	r.metrics.Bytes = 0
+	r.metricsLock.Unlock()
 }

--- a/webtunnelserver/webtunnelserver_test.go
+++ b/webtunnelserver/webtunnelserver_test.go
@@ -100,12 +100,12 @@ func TestServer(t *testing.T) {
 	}
 
 	// Test User Metrics status
-	metric := server.GetMetrics();
+	metric := server.GetMetrics()
 	if metric.MaxUsers != 253 {
-		t.Errorf("MaxUsers expected: 253, got: %v",metric.MaxUsers)
+		t.Errorf("MaxUsers expected: 253, got: %v", metric.MaxUsers)
 	}
 	if metric.Users != 1 {
-		t.Errorf("Users expected: 1, got: %v",metric.Users)
+		t.Errorf("Users expected: 1, got: %v", metric.Users)
 	}
 
 	// Close connection.


### PR DESCRIPTION
This fixes data race condition when running the unit tests with the -race flag.