### PR TITLE
Add session support to the client

### DIFF
--- a/webtunnelclient/client.go
+++ b/webtunnelclient/client.go
@@ -101,6 +101,7 @@ func NewWebtunnelClient(serverIPPort string, wsDialer *websocket.Dialer,
 		Error:        make(chan error),
 		isNetReady:   false,
 		isStopped:    false,
+		isWSReady:    false,
 		serverIPPort: serverIPPort,
 		wsDialer:     wsDialer,
 		devType:      devType,
@@ -137,6 +138,7 @@ func (w *WebtunnelClient) Start() error {
 		return err
 	}
 	w.wsconn = wsconn
+	w.isWSReady = true
 
 	// Start network interface.
 	handle, err := NewWaterInterface(water.Config{
@@ -250,6 +252,13 @@ func (w *WebtunnelClient) Retry() error {
 	if err != nil {
 		return err
 	}
+	wsconn, _, err := w.wsDialer.Dial(u.String(), nil)
+	if err != nil {
+		return err
+	}
+	w.wsconn = wsconn
+	w.isWSReady = true
+
 	configString := "getConfig" + " " + userinfo + " " + w.session
 	if err := w.wsconn.WriteMessage(websocket.TextMessage, []byte(configString)); err != nil {
 		return err

--- a/webtunnelclient/client.go
+++ b/webtunnelclient/client.go
@@ -252,6 +252,7 @@ func (w *WebtunnelClient) Retry() error {
 	if err != nil {
 		return err
 	}
+	u := url.URL{Scheme: w.scheme, Host: w.serverIPPort, Path: "/ws"}
 	wsconn, _, err := w.wsDialer.Dial(u.String(), nil)
 	if err != nil {
 		return err
@@ -275,7 +276,7 @@ func (w *WebtunnelClient) Retry() error {
 			cfg.ServerInfo.Session,
 		)
 	}
-	if net.ParseIP(cfg.IP).To4() != w.ifce.IP {
+	if !net.IP.Equal(net.ParseIP(cfg.IP).To4(), w.ifce.IP) {
 		return fmt.Errorf("Reconnect mismatch on IP, client wants: %v but server gives: %v",
 			w.ifce.IP,
 			net.ParseIP(cfg.IP).To4(),

--- a/webtunnelclient/client.go
+++ b/webtunnelclient/client.go
@@ -47,6 +47,7 @@ type Interface struct {
 // WebtunnelClient represents the client struct.
 type WebtunnelClient struct {
 	Error        chan error             // Channel to handle errors from goroutines.
+	isWSReady    bool                   // true when Websocket is ready - used when reconnecting
 	isNetReady   bool                   // true when network interface is ready.
 	isStopped    bool                   // True when Stop() called.
 	wsconn       *websocket.Conn        // Websocket connection.
@@ -64,6 +65,7 @@ type WebtunnelClient struct {
 	devType      water.DeviceType       // TUN/TAP.
 	scheme       string                 // Websocket Scheme.
 	leaseTime    uint32                 // DHCP lease time.
+	session      string                 // Session Tracker from Server
 }
 
 /*
@@ -231,12 +233,45 @@ func (w *WebtunnelClient) configureInterface() error {
 	w.ifce.RoutePrefix = routes
 	w.ifce.GWHWAddr = wc.GenMACAddr()
 
+	w.session = cfg.ServerInfo.Session
+
 	// Call user supplied function for any OS initializations needed from cli.
 	// Depending on OS this might be bringing up OS or other network commands.
 	if err := w.userInitFunc(w.ifce); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+// Retry the connection after a disconnection
+func (w *WebtunnelClient) Retry() error {
+	userinfo, err := w.getUserInfo()
+	if err != nil {
+		return err
+	}
+	configString := "getConfig" + " " + userinfo + " " + w.session
+	if err := w.wsconn.WriteMessage(websocket.TextMessage, []byte(configString)); err != nil {
+		return err
+	}
+	cfg := &wc.ClientConfig{}
+	if err := w.wsconn.ReadJSON(cfg); err != nil {
+		return err
+	}
+	glog.V(1).Infof("Retrieved config from server %v", *cfg)
+	// verify session config from server matches current config
+	if cfg.ServerInfo.Session != w.session {
+		return fmt.Errorf("Reconnect mismatch on session, client wants: %v but server gives: %v",
+			w.session,
+			cfg.ServerInfo.Session,
+		)
+	}
+	if net.ParseIP(cfg.IP).To4() != w.ifce.IP {
+		return fmt.Errorf("Reconnect mismatch on IP, client wants: %v but server gives: %v",
+			w.ifce.IP,
+			net.ParseIP(cfg.IP).To4(),
+		)
+	}
 	return nil
 }
 
@@ -302,6 +337,10 @@ func (w *WebtunnelClient) processWSPacket() {
 	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}
 
 	for {
+		// Skip if websocket is not ready - this means we are currently reconnecting
+		if !w.isWSReady {
+			continue
+		}
 		// Read packet from websocket.
 		w.wsReadLock.Lock()
 		mt, pkt, err := w.wsconn.ReadMessage()


### PR DESCRIPTION
Adding session support to the client - session is supported through a retry function.
The use of this function may or may not be used from the tunnel client creator depending on the desire to support or not sessions.