### PR TITLE
Update client.go

### DIFF
--- a/webtunnelclient/client.go
+++ b/webtunnelclient/client.go
@@ -476,9 +476,11 @@ func (w *WebtunnelClient) buildDHCPopts(leaseTime uint32, msgType layers.DHCPMsg
 	tm := make([]byte, 4)
 	binary.BigEndian.PutUint32(tm, leaseTime)
 
+	var dnsbytes []byte
 	for _, s := range w.ifce.DNS {
-		opt = append(opt, layers.NewDHCPOption(layers.DHCPOptDNS, s))
+		dnsbytes = append(dnsbytes, s...)
 	}
+	opt = append(opt, layers.NewDHCPOption(layers.DHCPOptDNS, dnsbytes))
 	opt = append(opt, layers.NewDHCPOption(layers.DHCPOptSubnetMask, w.ifce.Netmask))
 	opt = append(opt, layers.NewDHCPOption(layers.DHCPOptLeaseTime, tm))
 	opt = append(opt, layers.NewDHCPOption(layers.DHCPOptMessageType, []byte{byte(msgType)}))


### PR DESCRIPTION
Fix DNS servers advertising in dhcp lease.
Only the last DNS server was advertised as multiple DHCPOptDNS were provided. We need to provide only one DHCPOptDNS but which is the concatenation of the different dns servers IPs in []byte form.