### PR TITLE
Fix Arp reply bug with Windows 11 - Also start adding support for alternate tap driver name.

### DIFF
--- a/examples/webtunclient_windows.go
+++ b/examples/webtunclient_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+// webtunclient_windows.go Windows specific OS initialization for client.
+package main
+
+import (
+	"github.com/deepakkamesh/webtunnel/webtunnelclient"
+)
+
+// InitializeOS assigns IP to tunnel and sets up routing via tunnel.
+func InitializeOS(cfg *webtunnelclient.Interface) error {
+	return nil
+}

--- a/webtunnelclient/client.go
+++ b/webtunnelclient/client.go
@@ -146,7 +146,7 @@ func (w *WebtunnelClient) Start() error {
 
 	// Set alternate tap and interface name if specified
 	platformSpecConfig := water.PlatformSpecificParams{}
-	if w.windowsTapName != "tap0901" {
+	if w.isTap && (w.windowsTapName != "tap0901") {
 		platformSpecConfig = water.PlatformSpecificParams{
 			ComponentID: w.windowsTapName,
 			Network:     "192.168.1.0/24",

--- a/webtunnelclient/client.go
+++ b/webtunnelclient/client.go
@@ -46,26 +46,28 @@ type Interface struct {
 
 // WebtunnelClient represents the client struct.
 type WebtunnelClient struct {
-	Error        chan error             // Channel to handle errors from goroutines.
-	isWSReady    bool                   // true when Websocket is ready - used when reconnecting
-	isNetReady   bool                   // true when network interface is ready.
-	isStopped    bool                   // True when Stop() called.
-	wsconn       *websocket.Conn        // Websocket connection.
-	ifce         *Interface             // Struct to hold interface configuration.
-	userInitFunc func(*Interface) error // User supplied callback for OS initialization.
-	wsWriteLock  sync.Mutex             // Lock for Websocket Writes.
-	wsReadLock   sync.Mutex             // Lock for Websocket Reads.
-	metricsLock  sync.Mutex             // Lock for Metrics Writes.
-	ifReadLock   sync.Mutex             // Lock for Interface Reads.
-	ifWriteLock  sync.Mutex             // Lock for Interface Writes.
-	packetCnt    int                    // Count of packets.
-	bytesCnt     int                    // Count of bytes.
-	serverIPPort string                 // Websocket serverIP:Port.
-	wsDialer     *websocket.Dialer      // websocket dialer with options.
-	devType      water.DeviceType       // TUN/TAP.
-	scheme       string                 // Websocket Scheme.
-	leaseTime    uint32                 // DHCP lease time.
-	session      string                 // Session Tracker from Server
+	Error          chan error             // Channel to handle errors from goroutines.
+	isWSReady      bool                   // true when Websocket is ready - used when reconnecting
+	isNetReady     bool                   // true when network interface is ready.
+	isStopped      bool                   // True when Stop() called.
+	wsconn         *websocket.Conn        // Websocket connection.
+	ifce           *Interface             // Struct to hold interface configuration.
+	userInitFunc   func(*Interface) error // User supplied callback for OS initialization.
+	wsWriteLock    sync.Mutex             // Lock for Websocket Writes.
+	wsReadLock     sync.Mutex             // Lock for Websocket Reads.
+	metricsLock    sync.Mutex             // Lock for Metrics Writes.
+	ifReadLock     sync.Mutex             // Lock for Interface Reads.
+	ifWriteLock    sync.Mutex             // Lock for Interface Writes.
+	packetCnt      int                    // Count of packets.
+	bytesCnt       int                    // Count of bytes.
+	serverIPPort   string                 // Websocket serverIP:Port.
+	wsDialer       *websocket.Dialer      // websocket dialer with options.
+	devType        water.DeviceType       // TUN/TAP.
+	scheme         string                 // Websocket Scheme.
+	leaseTime      uint32                 // DHCP lease time.
+	session        string                 // Session Tracker from Server
+	isTap          bool                   // Is the webclient using a TAP interface
+	windowsTapName string                 // The TAP driver name - water default being "tap0901"
 }
 
 /*
@@ -98,16 +100,18 @@ func NewWebtunnelClient(serverIPPort string, wsDialer *websocket.Dialer,
 	}
 
 	return &WebtunnelClient{
-		Error:        make(chan error),
-		isNetReady:   false,
-		isStopped:    false,
-		isWSReady:    false,
-		serverIPPort: serverIPPort,
-		wsDialer:     wsDialer,
-		devType:      devType,
-		scheme:       scheme,
-		leaseTime:    leaseTime,
-		userInitFunc: f,
+		Error:          make(chan error),
+		isNetReady:     false,
+		isStopped:      false,
+		isWSReady:      false,
+		serverIPPort:   serverIPPort,
+		wsDialer:       wsDialer,
+		devType:        devType,
+		scheme:         scheme,
+		leaseTime:      leaseTime,
+		userInitFunc:   f,
+		isTap:          isTap,
+		windowsTapName: "tap0901",
 	}, nil
 }
 
@@ -140,9 +144,19 @@ func (w *WebtunnelClient) Start() error {
 	w.wsconn = wsconn
 	w.isWSReady = true
 
+	// Set alternate tap and interface name if specified
+	platformSpecConfig := water.PlatformSpecificParams{}
+	if w.windowsTapName != "tap0901" {
+		platformSpecConfig = water.PlatformSpecificParams{
+			ComponentID: w.windowsTapName,
+			Network:     "192.168.1.0/24",
+		}
+	}
+
 	// Start network interface.
 	handle, err := NewWaterInterface(water.Config{
-		DeviceType: w.devType,
+		DeviceType:             w.devType,
+		PlatformSpecificParams: platformSpecConfig,
 	})
 	if err != nil {
 		return fmt.Errorf("error creating int %s", err)
@@ -631,6 +645,17 @@ func (w *WebtunnelClient) handleArp(packet gopacket.Packet) error {
 		SrcMAC:       w.ifce.GWHWAddr,
 		DstMAC:       eth.SrcMAC,
 		EthernetType: layers.EthernetTypeARP,
+	}
+
+	// If the reply if for the VM TAP IP the source HW must be the TAP interface MAC addr
+	// Otherwise some Os could detect IP conflicts
+	if net.IP.Equal(net.IP(arpl.SourceProtAddress), w.ifce.IP) {
+		if w.ifce.LocalHWAddr == nil {
+			glog.V(2).Info("Interface is not yet ready - skip arp reply for the VM itself")
+			return nil
+		}
+		arpl.SourceHwAddress = w.ifce.LocalHWAddr
+		ethl.SrcMAC = w.ifce.LocalHWAddr
 	}
 
 	opts := gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true}

--- a/webtunnelclient/client.go
+++ b/webtunnelclient/client.go
@@ -46,28 +46,28 @@ type Interface struct {
 
 // WebtunnelClient represents the client struct.
 type WebtunnelClient struct {
-	Error          chan error             // Channel to handle errors from goroutines.
-	isWSReady      bool                   // true when Websocket is ready - used when reconnecting
-	isNetReady     bool                   // true when network interface is ready.
-	isStopped      bool                   // True when Stop() called.
-	wsconn         *websocket.Conn        // Websocket connection.
-	ifce           *Interface             // Struct to hold interface configuration.
-	userInitFunc   func(*Interface) error // User supplied callback for OS initialization.
-	wsWriteLock    sync.Mutex             // Lock for Websocket Writes.
-	wsReadLock     sync.Mutex             // Lock for Websocket Reads.
-	metricsLock    sync.Mutex             // Lock for Metrics Writes.
-	ifReadLock     sync.Mutex             // Lock for Interface Reads.
-	ifWriteLock    sync.Mutex             // Lock for Interface Writes.
-	packetCnt      int                    // Count of packets.
-	bytesCnt       int                    // Count of bytes.
-	serverIPPort   string                 // Websocket serverIP:Port.
-	wsDialer       *websocket.Dialer      // websocket dialer with options.
-	devType        water.DeviceType       // TUN/TAP.
-	scheme         string                 // Websocket Scheme.
-	leaseTime      uint32                 // DHCP lease time.
-	session        string                 // Session Tracker from Server
-	isTap          bool                   // Is the webclient using a TAP interface
-	windowsTapName string                 // The TAP driver name - water default being "tap0901"
+	Error          chan error                    // Channel to handle errors from goroutines.
+	isWSReady      bool                          // true when Websocket is ready - used when reconnecting
+	isNetReady     bool                          // true when network interface is ready.
+	isStopped      bool                          // True when Stop() called.
+	wsconn         *websocket.Conn               // Websocket connection.
+	ifce           *Interface                    // Struct to hold interface configuration.
+	userInitFunc   func(*Interface) error        // User supplied callback for OS initialization.
+	wsWriteLock    sync.Mutex                    // Lock for Websocket Writes.
+	wsReadLock     sync.Mutex                    // Lock for Websocket Reads.
+	metricsLock    sync.Mutex                    // Lock for Metrics Writes.
+	ifReadLock     sync.Mutex                    // Lock for Interface Reads.
+	ifWriteLock    sync.Mutex                    // Lock for Interface Writes.
+	packetCnt      int                           // Count of packets.
+	bytesCnt       int                           // Count of bytes.
+	serverIPPort   string                        // Websocket serverIP:Port.
+	wsDialer       *websocket.Dialer             // websocket dialer with options.
+	devType        water.DeviceType              // TUN/TAP.
+	scheme         string                        // Websocket Scheme.
+	leaseTime      uint32                        // DHCP lease time.
+	session        string                        // Session Tracker from Server
+	isTap          bool                          // Is the webclient using a TAP interface
+	customTapParam *water.PlatformSpecificParams // Tap driver specific parameters
 }
 
 /*
@@ -100,18 +100,17 @@ func NewWebtunnelClient(serverIPPort string, wsDialer *websocket.Dialer,
 	}
 
 	return &WebtunnelClient{
-		Error:          make(chan error),
-		isNetReady:     false,
-		isStopped:      false,
-		isWSReady:      false,
-		serverIPPort:   serverIPPort,
-		wsDialer:       wsDialer,
-		devType:        devType,
-		scheme:         scheme,
-		leaseTime:      leaseTime,
-		userInitFunc:   f,
-		isTap:          isTap,
-		windowsTapName: "tap0901",
+		Error:        make(chan error),
+		isNetReady:   false,
+		isStopped:    false,
+		isWSReady:    false,
+		serverIPPort: serverIPPort,
+		wsDialer:     wsDialer,
+		devType:      devType,
+		scheme:       scheme,
+		leaseTime:    leaseTime,
+		userInitFunc: f,
+		isTap:        isTap,
 	}, nil
 }
 
@@ -144,20 +143,16 @@ func (w *WebtunnelClient) Start() error {
 	w.wsconn = wsconn
 	w.isWSReady = true
 
-	// Set alternate tap and interface name if specified
-	platformSpecConfig := water.PlatformSpecificParams{}
-	if w.isTap && (w.windowsTapName != "tap0901") {
-		platformSpecConfig = water.PlatformSpecificParams{
-			ComponentID: w.windowsTapName,
-			Network:     "192.168.1.0/24",
-		}
+	// Set alternate tap parameter if provided
+	wtConfig := water.Config{
+		DeviceType: w.devType,
+	}
+	if w.isTap && (w.customTapParam != nil) {
+		wtConfig.PlatformSpecificParams = *w.customTapParam
 	}
 
 	// Start network interface.
-	handle, err := NewWaterInterface(water.Config{
-		DeviceType:             w.devType,
-		PlatformSpecificParams: platformSpecConfig,
-	})
+	handle, err := NewWaterInterface(wtConfig)
 	if err != nil {
 		return fmt.Errorf("error creating int %s", err)
 	}


### PR DESCRIPTION
The ARP reply will always have the remote Gateway random MAC as source.
This causes an issue when the ARP request wants to know who has the IP provided in the config for the client.
The client replies an ARP request saying the source MAC is the GW MAC and source IP is the client IP, this causes an IP conflict and on Windows 11 the TAP interface just disconnects and gets an undefined IP.

The interface is properly setup after the DHCP reply however, as soon as a ARP reply for the client IP is sent with the GW IP the interface disconnect. By modifying code and allowing DHCP reply to be sent even after the interface is detected as configured I can see the interface flapping in a state where the IP&routing table are ok and a state where no IP is assigned to the TAP interface, and routes are removed.

In Windows 11 event log I can see that Windows detects the IP of the client as duplicate and showing the generated GW HWaddr being the conflict. That helped me narrow done the issue that it was with the ARP replies.

Another thing I think is needed for future support of the tool is that OpenVPN new versions may use different driver names than tap0901. The water provides a way to change it but we don't.
