### PR TITLE
Add error case we want to ignore for the dns forwarder unit test.

### DIFF
--- a/webtunnelserver/dnsforwarder_test.go
+++ b/webtunnelserver/dnsforwarder_test.go
@@ -41,7 +41,7 @@ func TestListenServ(t *testing.T) {
 	if err != nil {
 		// check if it's because of Non Existent domain - we can ignore this
 		// as this means the test environment is not processing DNS requests
-		if strings.Contains(err, "Non-Existent domain") {
+		if strings.Contains(err.Error(), "Non-Existent domain") {
 			return
 		}
 		t.Error(err)

--- a/webtunnelserver/dnsforwarder_test.go
+++ b/webtunnelserver/dnsforwarder_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -38,6 +39,11 @@ func TestListenServ(t *testing.T) {
 
 	repIP, err := readDNSReply(conn)
 	if err != nil {
+		// check if it's because of Non Existent domain - we can ignore this
+		// as this means the test environment is not processing DNS requests
+		if strings.Contains(err, "Non-Existent domain") {
+			return
+		}
 		t.Error(err)
 	}
 	if repIP.String() != "8.8.8.8" {


### PR DESCRIPTION
Adding a test case failure to ignore in DNS forwarder unit test.
In some testing environments the DNS configuration may not be present and will return a non existent domain error that is safe to ignore.